### PR TITLE
added 0.025 SOL fee for registrations

### DIFF
--- a/programs/register/src/lib.rs
+++ b/programs/register/src/lib.rs
@@ -1,5 +1,9 @@
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::system_program;
+use anchor_lang::solana_program::system_instruction;
+use anchor_lang::solana_program::program::invoke;
+use anchor_lang::solana_program::pubkey::Pubkey;
+use std::str::FromStr;
 
 declare_id!("KdWVDYMteVwTbBNZGfCkS2ayCFEWhbkBoFZxPwdqCgu");
 
@@ -16,6 +20,25 @@ pub mod register {
         microtitle.bkey = bkey;
         microtitle.mint = mint; 
 
+        // pay the fee:
+        let fee: u64 = 25_000_000;
+
+        let ix = system_instruction::transfer(
+            ctx.accounts.author.key,
+            ctx.accounts.registrar.key,
+            fee
+        );
+        
+        invoke(
+            &ix,
+            &[
+                ctx.accounts.author.to_account_info(),
+                ctx.accounts.registrar.to_account_info(),
+                ctx.accounts.system_program.to_account_info(),
+            ],
+        )?;
+
+
         Ok(())
     }
 }
@@ -26,6 +49,8 @@ pub struct UpdateRegister<'info> {
     pub microtitle: Account<'info, Microtitle>,
     #[account(mut)]
     pub author: Signer<'info>,
+    #[account(mut, address = Pubkey::from_str("HSMaqKWmpKtibZrukaE4X3HatNDUYkzg39y2kri3PRTh").unwrap())]
+    pub registrar: AccountInfo<'info>,
     #[account(address = system_program::ID)]
     pub system_program: AccountInfo<'info>,
 }

--- a/tests/register.ts
+++ b/tests/register.ts
@@ -18,12 +18,14 @@ describe('register', () => {
     const utitle = anchor.web3.Keypair.generate();
     const bkey = new PublicKey('79SeGDwWgDmM2PdBHbpxnpKKLwEZmN6iZcNrNUQqkUfE')
     const mintId = new PublicKey('GQLWnE4WvVwwmvZPiC1EbkByKVXWGV3undLM52bqBLhK')
+    const registrarPubkey = new PublicKey('HSMaqKWmpKtibZrukaE4X3HatNDUYkzg39y2kri3PRTh');
    // const awallet = program.provider.wallet;
 
     await program.rpc.updateRegister(bkey, mintId, {
         accounts: {
             microtitle: utitle.publicKey,
             author: program.provider.wallet.publicKey,
+            registrar: registrarPubkey,
             systemProgram: anchor.web3.SystemProgram.programId,
         },
         signers: [utitle], // --> how to get the type Keypair from the type Wallet? You need the author to serve as the signer, payer.


### PR DESCRIPTION
Simple 0.025 SOL fee added for registrations that will help cover operating costs (hosting), and prevent spam and sybil attacks by means of the modest cost for adding microtitles to the register.  